### PR TITLE
Digest emep config correctly (cache file generation)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyaerocom_parallelization"
-version = "0.6.5"
+version = "0.6.6"
 authors = [{ name = "MET Norway" }]
 description = "run pyaerocom aeroval tasks in parallel on the Met Norway PPI infrastructure"
 readme = "README.md"

--- a/src/aeroval_parallelize/tools.py
+++ b/src/aeroval_parallelize/tools.py
@@ -735,12 +735,23 @@ def get_config_info(
         except KeyError:
             pass
 
-        var_config[cfg["obs_cfg"][_obs_network]["obs_id"]] = {}
-        var_config[cfg["obs_cfg"][_obs_network]["obs_id"]]["obs_vars"] = cfg["obs_cfg"][
-            _obs_network
-        ]["obs_vars"]
+        # leave out pyaro stuff for now...
+        if "pyaro_config" in cfg["obs_cfg"][_obs_network]:
+            continue
+
+        # skip calculated obs vars
+        if 'obs_aux_requires' in cfg["obs_cfg"][_obs_network]:
+            continue
+
+        if cfg["obs_cfg"][_obs_network]["obs_id"] not in var_config:
+            var_config[cfg["obs_cfg"][_obs_network]["obs_id"]] = {}
+            var_config[cfg["obs_cfg"][_obs_network]["obs_id"]]["obs_vars"] = cfg["obs_cfg"][_obs_network]["obs_vars"]
+        else:
+            var_config[cfg["obs_cfg"][_obs_network]["obs_id"]]["obs_vars"].extend(cfg["obs_cfg"][_obs_network]["obs_vars"])
         # check each obs_cfg entry for pyaro
         # if it exists, jsonpickle the pyaro config to be passed to cache file generation
+        # disabled for now, but left in here in case we reintroduce caching for pyaro based
+        # obs networks
         if "pyaro_config" in cfg["obs_cfg"][_obs_network]:
             var_config[cfg["obs_cfg"][_obs_network]["obs_id"]][
                 "pyaro_config"


### PR DESCRIPTION
The EMEP base config uses a lot of obs network renaming. 
Make sure that all (most) variables of pyaerocom internal obs networks are run through the cache file generation. 